### PR TITLE
Pass sitemap instances to Serialize in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ _Looking for ASP.NET Core integration, see [Sidio.Sitemap.AspNetCore](https://gi
 var nodes = new List<SitemapNode> { new ("https://example.com/page.html") };
 var sitemap = new Sitemap(nodes);
 var service = new SitemapService(new XmlSerializer());
-var xmlResult = service.Serialize();
+var xmlResult = service.Serialize(sitemap);
 ```
 
 ## Sitemap index
@@ -32,7 +32,7 @@ var xmlResult = service.Serialize();
 var sitemapIndexNodes = new List<SitemapIndexNode> { new("https://example.com/sitemap-1.xml") };
 var sitemapIndex = new SitemapIndex(sitemapIndexNodes);
 var service = new SitemapIndexService(new XmlSerializer());
-var xmlResult = service.Serialize();
+var xmlResult = service.Serialize(sitemapIndex);
 ```
 
 ## Dependency injection
@@ -47,7 +47,7 @@ public class MyClass()
     {
         var nodes = new List<SitemapNode> { new ("https://example.com/page.html") };
         var sitemap = new Sitemap(nodes);
-        var xmlResult = service.Serialize();
+        var xmlResult = service.Serialize(sitemap);
     }
 }    
 ```


### PR DESCRIPTION
Fix README usage examples where service.Serialize() was called without arguments. Updated three snippets to call service.Serialize(sitemap) or service.Serialize(sitemapIndex) so they match the API and prevent confusion in the sitemap, sitemap index, and dependency-injection examples.