### PR TITLE
Support hreflang alternate links in sitemap

### DIFF
--- a/src/Sidio.Sitemap.Core.Tests/Serialization/XmlSerializerTests.cs
+++ b/src/Sidio.Sitemap.Core.Tests/Serialization/XmlSerializerTests.cs
@@ -29,6 +29,35 @@ public sealed partial class XmlSerializerTests
     }
 
     [Fact]
+    public void Serialize_WithMultilingualSitemap_ReturnsXml()
+    {
+        // arrange
+        var sitemap = new Sitemap(
+            new List<SitemapNode>
+            {
+                new SitemapNode("http://example.com")
+                {
+                    AlternateLinks =
+                    [
+                        new SitemapAlternateLink("en", "http://example.com"),
+                        new SitemapAlternateLink("es", "http://example.com/es/"),
+                        new SitemapAlternateLink("x-default", "http://example.com")
+                    ]
+                }
+            });
+
+        var serializer = new XmlSerializer();
+
+        // act
+        var result = serializer.Serialize(sitemap);
+
+        // assert
+        result.Should().NotBeNullOrEmpty();
+        result.Should().Be(
+            $"<?xml version=\"1.0\" encoding=\"utf-8\" standalone=\"no\"?><urlset xmlns:xhtml=\"http://www.w3.org/1999/xhtml\" xmlns=\"http://www.sitemaps.org/schemas/sitemap/0.9\"><url><loc>http://example.com/</loc><xhtml:link rel=\"alternate\" hreflang=\"en\" href=\"http://example.com/\" /><xhtml:link rel=\"alternate\" hreflang=\"es\" href=\"http://example.com/es/\" /><xhtml:link rel=\"alternate\" hreflang=\"x-default\" href=\"http://example.com/\" /></url></urlset>");
+    }
+
+    [Fact]
     public void Serialize_WithStylesheet_ReturnsXml()
     {
         // arrange

--- a/src/Sidio.Sitemap.Core.Tests/SitemapAlternateLinkTests.cs
+++ b/src/Sidio.Sitemap.Core.Tests/SitemapAlternateLinkTests.cs
@@ -1,0 +1,27 @@
+﻿namespace Sidio.Sitemap.Core.Tests;
+
+public sealed class SitemapAlternateLinkTests
+{
+    [Theory]
+    [InlineData("en")]
+    [InlineData("en-US")]
+    [InlineData("x-default")]
+    public void Construct_WithValidArguments_SitemapNodeConstructed(string hrefLang)
+    {
+        var sitemapAlternateLink = new SitemapAlternateLink(hrefLang, "http://example.com/");
+        sitemapAlternateLink.Should().NotBeNull();
+    }
+
+    [Theory]
+    [InlineData("englisch")]
+    [InlineData("en_US")]
+    public void Construct_WithInvalidHrefLang_ThrowsArgumentException(string hrefLang)
+    {
+        // act
+        Action act = () => new SitemapAlternateLink(hrefLang, "http://example.com/");
+
+        // assert
+        act.Should().Throw<ArgumentException>()
+           .WithMessage("*hreflang*");
+    }
+}

--- a/src/Sidio.Sitemap.Core/Serialization/SitemapExtensions.cs
+++ b/src/Sidio.Sitemap.Core/Serialization/SitemapExtensions.cs
@@ -9,4 +9,6 @@ internal static class SitemapExtensions
     public static bool HasNewsNodes(this Sitemap sitemap) => sitemap.Nodes.Any(node => node is SitemapNewsNode);
 
     public static bool HasVideoNodes(this Sitemap sitemap) => sitemap.Nodes.Any(node => node is SitemapVideoNode);
+
+    public static bool HasSitemapNodeWithAlternateLinks(this Sitemap sitemap) => sitemap.Nodes.Any(node => node is SitemapNode sitemapNode && sitemapNode.AlternateLinks.Count > 0);
 }

--- a/src/Sidio.Sitemap.Core/Serialization/XmlSerializer.cs
+++ b/src/Sidio.Sitemap.Core/Serialization/XmlSerializer.cs
@@ -167,10 +167,12 @@ public sealed partial class XmlSerializer : ISitemapSerializer
         {
             foreach (var link in node.AlternateLinks)
             {
+                var linkUrl = _urlValidator.Validate(link.Href);
+
                 writer.WriteStartElement("xhtml", "link", SitemapNamespaceXhtml);
                 writer.WriteAttributeString("rel", link.Rel);
                 writer.WriteAttributeString("hreflang", link.HrefLang);
-                writer.WriteAttributeString("href", link.Href);
+                writer.WriteAttributeString("href", linkUrl.ToString());
                 writer.WriteEndElement();
             }
         }

--- a/src/Sidio.Sitemap.Core/Serialization/XmlSerializer.cs
+++ b/src/Sidio.Sitemap.Core/Serialization/XmlSerializer.cs
@@ -16,6 +16,7 @@ public sealed partial class XmlSerializer : ISitemapSerializer
     private const string SitemapNamespaceImage = "http://www.google.com/schemas/sitemap-image/1.1";
     private const string SitemapNamespaceNews = "http://www.google.com/schemas/sitemap-news/0.9";
     private const string SitemapNamespaceVideo = "http://www.google.com/schemas/sitemap-video/1.1";
+    private const string SitemapNamespaceXhtml = "http://www.w3.org/1999/xhtml";
     private const string SitemapDateFormat = "yyyy-MM-dd";
 
     private static readonly CultureInfo SitemapCulture = CultureInfo.InvariantCulture;
@@ -110,6 +111,7 @@ public sealed partial class XmlSerializer : ISitemapSerializer
         }
 
         writer.WriteStartElement(null, "urlset", SitemapNamespace);
+        writer.WriteAttributeString("xmlns", "xhtml", null, SitemapNamespaceXhtml);
         WriteNamespaces(writer, sitemap);
 
         foreach (var n in sitemap.Nodes)
@@ -155,6 +157,18 @@ public sealed partial class XmlSerializer : ISitemapSerializer
         if (node.Priority.HasValue)
         {
             writer.WriteElementStringEscaped("priority", node.Priority.Value.ToString("F1", SitemapCulture));
+        }
+
+        if (node.AlternateLinks.Length > 0)
+        {
+            foreach (var link in node.AlternateLinks)
+            {
+                writer.WriteStartElement("xhtml", "link", SitemapNamespaceXhtml);
+                writer.WriteAttributeString("rel", link.Rel);
+                writer.WriteAttributeString("hreflang", link.Hreflang);
+                writer.WriteAttributeString("href", link.Href);
+                writer.WriteEndElement();
+            }
         }
 
         writer.WriteEndElement();

--- a/src/Sidio.Sitemap.Core/Serialization/XmlSerializer.cs
+++ b/src/Sidio.Sitemap.Core/Serialization/XmlSerializer.cs
@@ -99,6 +99,11 @@ public sealed partial class XmlSerializer : ISitemapSerializer
         {
             writer.WriteAttributeString("xmlns", "video", null, SitemapNamespaceVideo);
         }
+
+        if (sitemap.HasSitemapNodeWithAlternateLinks())
+        {
+            writer.WriteAttributeString("xmlns", "xhtml", null, SitemapNamespaceXhtml);
+        }
     }
 
     private void SerializeSitemap(XmlWriter writer, Sitemap sitemap)
@@ -111,7 +116,6 @@ public sealed partial class XmlSerializer : ISitemapSerializer
         }
 
         writer.WriteStartElement(null, "urlset", SitemapNamespace);
-        writer.WriteAttributeString("xmlns", "xhtml", null, SitemapNamespaceXhtml);
         WriteNamespaces(writer, sitemap);
 
         foreach (var n in sitemap.Nodes)

--- a/src/Sidio.Sitemap.Core/Serialization/XmlSerializer.cs
+++ b/src/Sidio.Sitemap.Core/Serialization/XmlSerializer.cs
@@ -159,7 +159,7 @@ public sealed partial class XmlSerializer : ISitemapSerializer
             writer.WriteElementStringEscaped("priority", node.Priority.Value.ToString("F1", SitemapCulture));
         }
 
-        if (node.AlternateLinks.Length > 0)
+        if (node.AlternateLinks.Count > 0)
         {
             foreach (var link in node.AlternateLinks)
             {

--- a/src/Sidio.Sitemap.Core/Serialization/XmlSerializer.cs
+++ b/src/Sidio.Sitemap.Core/Serialization/XmlSerializer.cs
@@ -165,7 +165,7 @@ public sealed partial class XmlSerializer : ISitemapSerializer
             {
                 writer.WriteStartElement("xhtml", "link", SitemapNamespaceXhtml);
                 writer.WriteAttributeString("rel", link.Rel);
-                writer.WriteAttributeString("hreflang", link.Hreflang);
+                writer.WriteAttributeString("hreflang", link.HrefLang);
                 writer.WriteAttributeString("href", link.Href);
                 writer.WriteEndElement();
             }

--- a/src/Sidio.Sitemap.Core/SitemapAlternateLink.cs
+++ b/src/Sidio.Sitemap.Core/SitemapAlternateLink.cs
@@ -15,11 +15,6 @@
         /// <exception cref="ArgumentException">Thrown when <paramref name="hrefLang"/> or <paramref name="href"/> is null, empty, or consists only of white-space characters.</exception>
         public SitemapAlternateLink(string? hrefLang, string? href, string rel = "alternate")
         {
-            if (string.IsNullOrWhiteSpace(hrefLang))
-            {
-                throw new ArgumentException($"{nameof(hrefLang)} cannot be null or empty.", nameof(hrefLang));
-            }
-
             if (!IsValidHreflang(hrefLang))
             {
                 throw new ArgumentException(

--- a/src/Sidio.Sitemap.Core/SitemapAlternateLink.cs
+++ b/src/Sidio.Sitemap.Core/SitemapAlternateLink.cs
@@ -27,8 +27,8 @@
                 throw new ArgumentException($"{nameof(href)} cannot be null or empty.", nameof(href));
             }
 
-            HrefLang = hrefLang;
-            Href = href;
+            HrefLang = hrefLang!;
+            Href = href!;
             Rel = rel;
         }
 
@@ -58,7 +58,7 @@
                 return false;
             }
 
-            if (hreflang.Equals("x-default", StringComparison.OrdinalIgnoreCase))
+            if (hreflang!.Equals("x-default", StringComparison.OrdinalIgnoreCase))
             {
                 return true;
             }

--- a/src/Sidio.Sitemap.Core/SitemapAlternateLink.cs
+++ b/src/Sidio.Sitemap.Core/SitemapAlternateLink.cs
@@ -7,21 +7,84 @@
     public class SitemapAlternateLink
     {
         /// <summary>
+        /// Initializes a new instance of the <see cref="SitemapAlternateLink"/> class.
+        /// </summary>
+        /// <param name="hrefLang">The language and optional region code (e.g., "en", "en-us") for the localized version.</param>
+        /// <param name="href">The fully qualified absolute URL of the localized version of the page.</param>
+        /// <param name="rel">The relationship of the linked document. Defaults to "alternate".</param>
+        /// <exception cref="ArgumentException">Thrown when <paramref name="hrefLang"/> or <paramref name="href"/> is null, empty, or consists only of white-space characters.</exception>
+        public SitemapAlternateLink(string? hrefLang, string? href, string rel = "alternate")
+        {
+            if (string.IsNullOrWhiteSpace(hrefLang))
+            {
+                throw new ArgumentException($"{nameof(hrefLang)} cannot be null or empty.", nameof(hrefLang));
+            }
+
+            if (!IsValidHreflang(hrefLang))
+            {
+                throw new ArgumentException(
+                    $"The value '{hrefLang}' is not a valid hreflang. Expected formats: 'x-default', 2-letter ISO code (e.g., 'en'), or 5-character language-region code (e.g., 'en-US').",
+                    nameof(hrefLang));
+            }
+
+            if (string.IsNullOrWhiteSpace(href))
+            {
+                throw new ArgumentException($"{nameof(href)} cannot be null or empty.", nameof(href));
+            }
+
+            HrefLang = hrefLang;
+            Href = href;
+            Rel = rel;
+        }
+
+
+        /// <summary>
         /// Gets or sets the relationship of the linked document. 
         /// For sitemaps, this must always be set to "alternate".
         /// </summary>
-        public string Rel { get; set; } = "alternate";
+        public string Rel { get; }
 
         /// <summary>
         /// Gets or sets the language and optional region code of the variant. 
         /// Follows the ISO 639-1 format for languages and ISO 3166-1 Alpha-2 for regions (e.g., "en-us"). 
         /// Use "x-default" for unmatched languages.
         /// </summary>
-        public string? HrefLang { get; set; }
+        public string HrefLang { get; }
 
         /// <summary>
         /// Gets or sets the fully qualified absolute URL of the localized version.
         /// </summary>
-        public string? Href { get; set; }
+        public string Href { get; }
+
+        private static bool IsValidHreflang(string? hreflang)
+        {
+            if (string.IsNullOrWhiteSpace(hreflang))
+            {
+                return false;
+            }
+
+            if (hreflang.Equals("x-default", StringComparison.OrdinalIgnoreCase))
+            {
+                return true;
+            }
+
+            int length = hreflang.Length;
+
+            if (length == 2)
+            {
+                return char.IsLetter(hreflang[0]) && char.IsLetter(hreflang[1]);
+            }
+
+            if (length == 5)
+            {
+                return char.IsLetter(hreflang[0]) &&
+                       char.IsLetter(hreflang[1]) &&
+                       hreflang[2] == '-' &&
+                       char.IsLetter(hreflang[3]) &&
+                       char.IsLetter(hreflang[4]);
+            }
+
+            return false;
+        }
     }
 }

--- a/src/Sidio.Sitemap.Core/SitemapAlternateLink.cs
+++ b/src/Sidio.Sitemap.Core/SitemapAlternateLink.cs
@@ -17,7 +17,7 @@
         /// Follows the ISO 639-1 format for languages and ISO 3166-1 Alpha-2 for regions (e.g., "en-us"). 
         /// Use "x-default" for unmatched languages.
         /// </summary>
-        public string? Hreflang { get; set; }
+        public string? HrefLang { get; set; }
 
         /// <summary>
         /// Gets or sets the fully qualified absolute URL of the localized version.

--- a/src/Sidio.Sitemap.Core/SitemapAlternateLink.cs
+++ b/src/Sidio.Sitemap.Core/SitemapAlternateLink.cs
@@ -1,0 +1,27 @@
+﻿namespace Sidio.Sitemap.Core
+{
+    /// <summary>
+    /// Represents an HTML link element for specifying localized versions of a URL (hreflang) 
+    /// within a sitemap, conforming to the XHTML namespace.
+    /// </summary>
+    public class SitemapAlternateLink
+    {
+        /// <summary>
+        /// Gets or sets the relationship of the linked document. 
+        /// For sitemaps, this must always be set to "alternate".
+        /// </summary>
+        public string Rel { get; set; } = "alternate";
+
+        /// <summary>
+        /// Gets or sets the language and optional region code of the variant. 
+        /// Follows the ISO 639-1 format for languages and ISO 3166-1 Alpha-2 for regions (e.g., "en-us"). 
+        /// Use "x-default" for unmatched languages.
+        /// </summary>
+        public string? Hreflang { get; set; }
+
+        /// <summary>
+        /// Gets or sets the fully qualified absolute URL of the localized version.
+        /// </summary>
+        public string? Href { get; set; }
+    }
+}

--- a/src/Sidio.Sitemap.Core/SitemapAlternateLink.cs
+++ b/src/Sidio.Sitemap.Core/SitemapAlternateLink.cs
@@ -32,7 +32,6 @@
             Rel = rel;
         }
 
-
         /// <summary>
         /// Gets or sets the relationship of the linked document. 
         /// For sitemaps, this must always be set to "alternate".

--- a/src/Sidio.Sitemap.Core/SitemapNode.cs
+++ b/src/Sidio.Sitemap.Core/SitemapNode.cs
@@ -36,7 +36,7 @@ public sealed record SitemapNode : ISitemapNode
     /// Gets or sets a collection of alternate localized URLs for this node.
     /// Used for cross-referencing pages with different languages or regional variants (hreflang).
     /// </summary>
-    public SitemapAlternateLink[] AlternateLinks { get; set; } = [];
+    public IReadOnlyList<SitemapAlternateLink> AlternateLinks { get; set; } = [];
 
     /// <summary>
     /// Gets or sets the date of last modification of the page.

--- a/src/Sidio.Sitemap.Core/SitemapNode.cs
+++ b/src/Sidio.Sitemap.Core/SitemapNode.cs
@@ -33,6 +33,12 @@ public sealed record SitemapNode : ISitemapNode
     public string Url { get; }
 
     /// <summary>
+    /// Gets or sets a collection of alternate localized URLs for this node.
+    /// Used for cross-referencing pages with different languages or regional variants (hreflang).
+    /// </summary>
+    public SitemapAlternateLink[] AlternateLinks { get; set; } = [];
+
+    /// <summary>
     /// Gets or sets the date of last modification of the page.
     /// </summary>
     public DateTime? LastModified { get; set; }


### PR DESCRIPTION
Add support for XHTML alternate (hreflang) links in sitemaps. Introduces SitemapAlternateLink model to represent rel/hreflang/href attributes, adds an AlternateLinks array to SitemapNode (initialized empty), and updates XmlSerializer to declare the xhtml namespace and emit <xhtml:link> elements for each alternate link when present. This enables publishing localized/region-specific URL variants in the sitemap.


```cs
var sitemapNode = new SitemapNode("http://test.com")
{
    AlternateLinks =
    [
        new SitemapAlternateLink("es", "http://test.com/es"),
        new SitemapAlternateLink("x-default", "http://test.com")
    ]
};
```